### PR TITLE
Add `pydna` library to design tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ to maximize on-target activity for target(s) provided. **Recommended**
 - [PrimeDesign](http://primedesign.pinellolab.org/) - [webserver, software] -  A flexible and comprehensive design tool for prime editing.
 - [Primeedit](https://primeedit.nygenome.org/) - [webserver] - This website designs pegRNAs and secondary sgRNAs for PE2, PE3 and PE3b prime editors for ClinVar human pathogenic variants.
 - [Protospacer Workbench](http://www.protospacer.com) - [software] - Protospacer Workbench offers an interface for finding, evaluating, and sharing Cas9 guide-RNA (gRNA) designs.
+- [pydna](https://github.com/pydna-group/pydna) - [python] - A Python library to simulate and document reproducible cloning strategies, including sgRNA design and CRISPR-mediated engineering. [BMC Bioinfo](https://doi.org/10.1186/s12859-015-0544-x)
 - [sgRNA Scorerv2.0](https://sgrnascorer.cancer.gov/)- [python, webserver] - A software allows users to identify sgRNA sites for any PAM sequence of interest.
 - [SSC](http://cistrome.org/SSC/) - [webserver] - A sequence model for predicting sgRNA efficiency in CRISPR/Cas9 knockout experiments.
 - [SSFinder](https://code.google.com/archive/p/ssfinder/) - [software] - A high throughput CRISPR-Cas target sites prediction tool.


### PR DESCRIPTION
Adding `pydna`, a Python library to simulate and document reproducible cloning strategies, including (but not limited to) sgRNA design and CRISPR-mediated engineering.

I am a contributor of this library.

Would it be worth it to add another category gathering "all in one" cloning solutions? Tools such as Benchling or pydna?

cc @manulera @BjornFJohansson @hiyama341